### PR TITLE
Add root directory for ftp server. Fix some bugs on huawei p6.

### DIFF
--- a/src/net/micode/fileexplorer/FileExplorerPreferenceActivity.java
+++ b/src/net/micode/fileexplorer/FileExplorerPreferenceActivity.java
@@ -20,6 +20,7 @@
 package net.micode.fileexplorer;
 
 import java.io.File;
+import java.io.IOException;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -104,7 +105,22 @@ public class FileExplorerPreferenceActivity extends PreferenceActivity implement
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
 
         boolean isReadRootFromSetting = settings.getBoolean(READ_ROOT, false);
-        boolean isReadRootWhenSettingPrimaryFolderWithoutSdCardPrefix = !getPrimaryFolder(context).startsWith(Util.getSdDirectory());
+        boolean isReadRootWhenSettingPrimaryFolderWithoutSdCardPrefix;
+
+        /*  Modified by Nova, fix a bug.
+         *  In huawei p6, Util.getSdDirectory() returns "/storage/emulated/0", primary folder is "/mnt/sdcard", they are the same,
+         *  it make isReadRootWhenSettingPrimaryFolderWithoutSdCardPrefix get a wrong value.
+         */
+        String primary, sd;
+        try {
+            primary = (new File(getPrimaryFolder(context))).getCanonicalPath();
+            sd = (new File(Util.getSdDirectory())).getCanonicalPath();
+        } catch (IOException e) {
+            e.printStackTrace();
+            primary = getPrimaryFolder(context);
+            sd = Util.getSdDirectory();
+        }
+        isReadRootWhenSettingPrimaryFolderWithoutSdCardPrefix = !primary.startsWith(sd);
 
         return isReadRootFromSetting || isReadRootWhenSettingPrimaryFolderWithoutSdCardPrefix;
     }

--- a/src/net/micode/fileexplorer/FileViewActivity.java
+++ b/src/net/micode/fileexplorer/FileViewActivity.java
@@ -20,6 +20,7 @@
 package net.micode.fileexplorer;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -174,6 +175,14 @@ public class FileViewActivity extends Fragment implements
                 currentDir = uri.getPath();
             }
         }
+
+        // added by Nova, for root path checking.
+        try {
+            currentDir = new File(currentDir).getCanonicalPath();
+        } catch (IOException e) {
+            Log.d(LOG_TAG, "fail to get CanonicalPath, currentDir = " + currentDir);
+        }
+
         mFileViewInteractionHub.setCurrentPath(currentDir);
         Log.i(LOG_TAG, "CurrentDir = " + currentDir);
 

--- a/src/net/micode/fileexplorer/ServerControlActivity.java
+++ b/src/net/micode/fileexplorer/ServerControlActivity.java
@@ -246,7 +246,18 @@ public class ServerControlActivity extends Fragment implements IBackPressedListe
     OnClickListener startStopListener = new OnClickListener() {
         public void onClick(View v) {
             Globals.setLastError(null);
-            File chrootDir = new File(Defaults.chrootDir);
+
+            /*
+             *  check whether ftp user can access root path according to the settings.
+             *  added by Nova.
+             */
+            File chrootDir;
+            if (FileExplorerPreferenceActivity.isReadRoot(mActivity)) {
+                chrootDir = new File(GlobalConsts.ROOT_PATH);   // system root, "/"
+            } else {
+                chrootDir = new File(Defaults.chrootDir);   // sd home
+            }
+
             if (!chrootDir.isDirectory())
                 return;
 
@@ -254,6 +265,8 @@ public class ServerControlActivity extends Fragment implements IBackPressedListe
             Intent intent = new Intent(context, FTPServerService.class);
 
             Globals.setChrootDir(chrootDir);
+            Globals.setPrimaryDir(new File(Defaults.chrootDir));
+
             if (!FTPServerService.isRunning()) {
                 warnIfNoExternalStorage();
                 if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {

--- a/src/org/swiftp/CmdPWD.java
+++ b/src/org/swiftp/CmdPWD.java
@@ -43,7 +43,11 @@ public class CmdPWD extends FtpCmd implements Runnable {
             File workingDir = sessionThread.getWorkingDir();
             String currentDir = workingDir != null ? workingDir.getCanonicalPath() : Globals.getChrootDir()
                     .getCanonicalPath();
-            currentDir = currentDir.substring(Globals.getChrootDir().getCanonicalPath().length());
+
+            // modified by nova, if root path is "/", it requires special handling
+            if (!Globals.getChrootDir().getCanonicalPath().equals("/")) {
+                currentDir = currentDir.substring(Globals.getChrootDir().getCanonicalPath().length());
+            }
             // The root directory requires special handling to restore its
             // leading slash
             if (currentDir.length() == 0) {

--- a/src/org/swiftp/Globals.java
+++ b/src/org/swiftp/Globals.java
@@ -27,6 +27,7 @@ public class Globals {
     private static Context context;
     private static String lastError;
     private static File chrootDir = new File(Defaults.chrootDir);
+    private static File primaryDir = chrootDir;    // added by Nova, set primary directory for ftp user.
     private static ProxyConnector proxyConnector = null;
     private static String username = null;
 
@@ -50,6 +51,31 @@ public class Globals {
     public static void setChrootDir(File chrootDir) {
         if(chrootDir.isDirectory()) {
             Globals.chrootDir = chrootDir;
+            Globals.primaryDir = chrootDir;
+        }
+    }
+
+    /** Get primary directory for ftp user.
+     */
+    public static File getPrimaryDir() {
+        return primaryDir;
+    }
+
+    /** Set primary directory for ftp user. when root directory is "/", we can change the primary directory of ftp user by setting this value.
+     *  Notes:
+     *   1. It must be invoked after setChrootDir.
+     *   2. Globals.primaryDir must be subdirectory of Globals.chrootDir.
+     */
+    public static void setPrimaryDir(File dir) {
+        if (dir.isDirectory()) {
+            try {
+                if (dir.getCanonicalPath().startsWith(Globals.getChrootDir().getPath())) {
+                    Globals.primaryDir = dir; // the primary directory name must begin with the Globals.chrootDir.
+                }
+                return ;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/org/swiftp/SessionThread.java
+++ b/src/org/swiftp/SessionThread.java
@@ -45,7 +45,7 @@ public class SessionThread extends Thread {
     protected boolean binaryMode = false;
     protected Account account = new Account();
     protected boolean authenticated = false;
-    protected File workingDir = Globals.getChrootDir();
+    protected File workingDir = Globals.getPrimaryDir();
     // protected ServerSocket dataServerSocket = null;
     protected Socket dataSocket = null;
     // protected FTPServerService service;
@@ -247,7 +247,7 @@ public class SessionThread extends Thread {
 
     static int numNulls = 0;
     public void run() {
-        myLog.l(Log.INFO, "SessionThread started");
+        myLog.l(Log.INFO, "SessionThread started. root = " + Globals.getChrootDir() + ", primary dir = " + Globals.getPrimaryDir());
 
         if(sendWelcomeBanner) {
             writeString("220 SwiFTP " + Util.getVersion() + " ready\r\n");


### PR DESCRIPTION
1、增加了ftp server功能对root目录支持，这样用户可以方便地通过ftp访问外置sd卡上的内容。
2、修改了在huawei P6上运行时的部分bug，在华为P6, Util.getSdDirectory() 返回 "/storage/emulated/0", 而primary folder 是 "/mnt/sdcard", 但他们是同一个目录，造成原代码中判断错误。
